### PR TITLE
Remove #by used with the #not_to method

### DIFF
--- a/lib/selleo-controller_tests/support/shared_examples/controllers/action_creating_object.rb
+++ b/lib/selleo-controller_tests/support/shared_examples/controllers/action_creating_object.rb
@@ -7,7 +7,7 @@ shared_examples_for 'an action creating object' do |*args|
   let(:new_attributes) { attributes }
 
   if opts[:expect_failure]
-    it { expect { call_request }.to_not change { model_class.count }.by(1) }
+    it { expect { call_request }.not_to change { model_class.count } }
   else
     it { expect { call_request }.to change { model_class.count }.by(1) }
   end


### PR DESCRIPTION
It's explain https://github.com/rspec/rspec-expectations/commit/953e3b36217ffa491a75bc327e878382dbc22941
and it cause error 'expect { }.not_to change { }.by()` is not supported'
