### PR TITLE
Update action_destroying_object.rb

### DIFF
--- a/lib/selleo-controller_tests/support/shared_examples/controllers/action_destroying_object.rb
+++ b/lib/selleo-controller_tests/support/shared_examples/controllers/action_destroying_object.rb
@@ -7,7 +7,7 @@ shared_examples_for 'an action destroying object' do |*args|
   let(:object) { public_send(model_name) }
 
   if opts[:expect_failure]
-    it { expect { call_request }.to_not change { object.class.count }.by(-1) }
+    it { expect { call_request }.to_not change { object.class.count } }
   else
     it { expect { call_request }.to change { object.class.count }.by(-1) }
   end


### PR DESCRIPTION
Dropped .by for not_to because it is deprecated