### PR TITLE
Adds expectation to check if new_attributes is not empty hash.

### DIFF
--- a/lib/selleo-controller_tests/support/shared_examples/controllers/action_creating_object.rb
+++ b/lib/selleo-controller_tests/support/shared_examples/controllers/action_creating_object.rb
@@ -4,7 +4,7 @@ shared_examples_for 'an action creating object' do |*args|
   subject { model_class.last }
 
   let(:model_class) { described_class.controller_name.classify.constantize }
-  let(:new_attributes) { attributes }
+  let(:new_attributes) { attributes.slice(*args.flatten).stringify_keys }
 
   if opts[:expect_failure]
     it { expect { call_request }.not_to change { model_class.count } }
@@ -16,7 +16,7 @@ shared_examples_for 'an action creating object' do |*args|
     context 'after call_request' do
       before { call_request }
 
-      it { expect(subject.attributes).to include(new_attributes.slice(*args.flatten).stringify_keys)}
+      it { expect(subject.attributes).to include(new_attributes) }
     end
   end
 end

--- a/lib/selleo-controller_tests/support/shared_examples/controllers/action_updating_object.rb
+++ b/lib/selleo-controller_tests/support/shared_examples/controllers/action_updating_object.rb
@@ -5,15 +5,25 @@ shared_examples_for 'an action updating object' do |*args|
 
   let(:model_name) { described_class.controller_name.singularize }
   let(:object) { public_send(model_name) }
-  let(:new_attributes) { attributes }
+  let(:new_attributes) { attributes.slice(*args.flatten).stringify_keys }
 
   context 'after call_request' do
-    before { call_request }
+    before do
+      if new_attributes.empty?
+        warn <<MESSAGE
+Unable to check if #{subject.class} was updated.
+You have to provide symbol of field that could have been changed in the process of update
+#{self.class.parent.metadata[:location]}
+MESSAGE
+      else
+        call_request
+      end
+    end
 
     if opts[:expect_failure]
-      it { expect(subject.reload.attributes).to_not include(new_attributes.slice(*args.flatten).stringify_keys) }
+      it { expect(subject.reload.attributes).to_not include(new_attributes) }
     else
-      it { expect(subject.reload.attributes).to include(new_attributes.slice(*args.flatten).stringify_keys) }
+      it { expect(subject.reload.attributes).to include(new_attributes) }
     end
   end
 end


### PR DESCRIPTION
@stevo @simon2k 
If arguments (args) are not provided, or do not match attributes, new_attributes are empty hash.
This cause #include expectations to always pass. Added expectation prevents such case.
